### PR TITLE
Fix warm pool reuse_on_scale_in argument

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -16,7 +16,9 @@ resource "aws_autoscaling_group" "workers" {
     for_each = var.warm_pool_capacity > 0 ? [1] : []
     content {
       max_group_prepared_capacity = var.warm_pool_capacity
-      reuse_on_scale_in           = true
+      instance_reuse_policy {
+        reuse_on_scale_in = true
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- wrap `reuse_on_scale_in` in `instance_reuse_policy` block

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ec543b4832ca8dcecac6727037c