### PR TITLE
Fix scale-in policy step adjustment argument

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -21,6 +21,6 @@ resource "aws_autoscaling_policy" "scale_in" {
 
   step_adjustment {
     metric_interval_lower_bound = 0
-    adjustment                  = -1
+    scaling_adjustment          = -1
   }
 }


### PR DESCRIPTION
## Summary
- fix autoscaling policy argument to use `scaling_adjustment`

## Testing
- `terraform fmt -check -recursive`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_684e1fc95a54832c84a246208ec8292f