### PR TITLE
Add optional Fluent Bit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ No modules.
 | <a name="input_ecr_repo"></a> [ecr\_repo](#input\_ecr\_repo) | ECR repository URI | `string` | n/a | yes |
 | <a name="input_enable_gpu"></a> [enable\_gpu](#input\_enable\_gpu) | Whether worker containers require GPU access | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `string` | n/a | yes |
+| <a name="input_fluentbit_config_ssm_path"></a> [fluentbit\_config\_ssm\_path](#input\_fluentbit\_config\_ssm\_path) | SSM parameter name containing Fluent Bit configuration. When empty, Fluent Bit is not deployed | `string` | `""` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Tag of the container image to run | `string` | `"latest"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | n/a | `string` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -1,12 +1,13 @@
 locals {
   user_data = templatefile("${path.module}/user_data.sh.tpl", {
-    region               = var.aws_region,
-    repo                 = var.ecr_repo,
-    tag                  = var.image_tag,
-    worker_command       = var.worker_command,
-    worker_env           = var.worker_env,
-    worker_secret_ids    = var.worker_secret_ids,
-    workers_per_instance = var.workers_per_instance,
-    enable_gpu           = var.enable_gpu
+    region                    = var.aws_region,
+    repo                      = var.ecr_repo,
+    tag                       = var.image_tag,
+    worker_command            = var.worker_command,
+    worker_env                = var.worker_env,
+    worker_secret_ids         = var.worker_secret_ids,
+    workers_per_instance      = var.workers_per_instance,
+    enable_gpu                = var.enable_gpu,
+    fluentbit_config_ssm_path = var.fluentbit_config_ssm_path
   })
 }

--- a/user_data.sh.tpl
+++ b/user_data.sh.tpl
@@ -7,10 +7,15 @@ tag="${tag}"
 command="${worker_command}"
 workers=${workers_per_instance}
 secrets="${worker_secret_ids}"
+fluentbit_config="${fluentbit_config_ssm_path}"
 
 systemctl enable --now docker
 
 mkdir -p /opt/app
+mkdir -p /opt/fluent-bit
+if [ -n "$fluentbit_config" ]; then
+  aws ssm get-parameter --region ${region} --name "$fluentbit_config" --with-decryption --query Parameter.Value --output text > /opt/fluent-bit/fluent-bit.conf
+fi
 if [ -n "$secrets" ]; then
   : > /opt/app/secrets.env
   for sid in $secrets; do
@@ -40,6 +45,13 @@ services:
 %{ endif }
     deploy:
       replicas: ${workers_per_instance}
+%{ if fluentbit_config_ssm_path != "" }
+  fluent-bit:
+    image: fluent/fluent-bit:latest
+    volumes:
+      - /opt/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+%{ endif }
 YML
 %{ if enable_gpu }
 export CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=$((100 / workers))

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,12 @@ variable "worker_secret_ids" {
   description = "List of Secrets Manager secret ARNs or names whose JSON values are converted to environment variables"
 }
 
+variable "fluentbit_config_ssm_path" {
+  type        = string
+  default     = ""
+  description = "SSM parameter name containing Fluent Bit configuration. When empty, Fluent Bit is not deployed"
+}
+
 variable "enable_gpu" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Summary
- support optional Fluent Bit sidecar with config from SSM
- generate user data to fetch config and add service
- document new variable in README

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_684e8f216788832ca1e261ca9317859d