### PR TITLE
Improve naming and IAM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ module "workers" {
   source  = "./"
 
   environment          = "prod"
+  name                 = "queue-worker"
   aws_region           = "eu-west-1"
   ami_id               = "ami-0123456789abcdef0"
   instance_type        = "g5.4xlarge"    # use a CPU instance type if GPUs aren't needed
@@ -37,6 +38,16 @@ module "workers" {
   workers_per_instance = 5
   asg_max_size         = 10
   warm_pool_capacity   = 2
+  additional_policies  = [
+    jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect = "Allow"
+        Action = ["s3:ListBucket"]
+        Resource = "arn:aws:s3:::example-bucket"
+      }]
+    })
+  ]
 }
 ```
 
@@ -83,6 +94,7 @@ No modules.
 | [aws_cloudwatch_metric_alarm.queue_empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_instance_profile.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.cw_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecr_pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -93,6 +105,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_policies"></a> [additional\_policies](#input\_additional\_policies) | List of additional IAM policy documents to attach to the worker role | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID with Docker and needed drivers installed | `string` | n/a | yes |
 | <a name="input_asg_desired_capacity"></a> [asg\_desired\_capacity](#input\_asg\_desired\_capacity) | n/a | `number` | `0` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | n/a | `number` | `5` | no |
@@ -105,6 +118,7 @@ No modules.
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Tag of the container image to run | `string` | `"latest"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | n/a | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the application or workload | `string` | n/a | yes |
 | <a name="input_private_subnets_ids"></a> [private\_subnets\_ids](#input\_private\_subnets\_ids) | n/a | `list(string)` | n/a | yes |
 | <a name="input_queue_empty_minutes"></a> [queue\_empty\_minutes](#input\_queue\_empty\_minutes) | n/a | `number` | `15` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | n/a | `list(string)` | n/a | yes |

--- a/asg.tf
+++ b/asg.tf
@@ -1,5 +1,5 @@
 resource "aws_autoscaling_group" "workers" {
-  name                = "${var.environment}-worker-asg"
+  name                = "${var.environment}-${var.name}-asg"
   max_size            = var.asg_max_size
   min_size            = var.asg_min_size
   desired_capacity    = var.asg_desired_capacity

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "worker" {
-  name = "${var.environment}-worker-role"
+  name = "${var.environment}-${var.name}-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -27,8 +27,9 @@ resource "aws_iam_role_policy_attachment" "cw_agent" {
 
 # Add CloudWatch Logs permissions for Fluent Bit
 resource "aws_iam_role_policy" "cloudwatch_logs" {
-  name = "${var.environment}-cloudwatch-logs"
-  role = aws_iam_role.worker.id
+  count = var.fluentbit_config_ssm_path != "" ? 1 : 0
+  name  = "${var.environment}-${var.name}-cloudwatch-logs"
+  role  = aws_iam_role.worker.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -43,17 +44,22 @@ resource "aws_iam_role_policy" "cloudwatch_logs" {
         Resource = "arn:aws:logs:*:*:*"
       },
       {
-        Effect = "Allow"
-        Action = [
-          "ssm:GetParameter"
-        ]
-        Resource = "arn:aws:ssm:*:*:parameter/fluent-bit"
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameter"]
+        Resource = "arn:aws:ssm:*:*:parameter${var.fluentbit_config_ssm_path}"
       }
     ]
   })
 }
 
 resource "aws_iam_instance_profile" "worker" {
-  name = "${var.environment}-worker-profile"
+  name = "${var.environment}-${var.name}-profile"
   role = aws_iam_role.worker.name
+}
+
+resource "aws_iam_role_policy" "additional" {
+  for_each = { for idx, policy in var.additional_policies : idx => policy }
+  name     = "${var.environment}-${var.name}-additional-${each.key}"
+  role     = aws_iam_role.worker.id
+  policy   = each.value
 }

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -1,5 +1,5 @@
 resource "aws_launch_template" "worker" {
-  name_prefix   = "${var.environment}-worker-"
+  name_prefix   = "${var.environment}-${var.name}-"
   image_id      = var.ami_id
   instance_type = var.instance_type
   key_name      = var.key_name
@@ -25,7 +25,7 @@ resource "aws_launch_template" "worker" {
     resource_type = "instance"
     tags = {
       Environment = var.environment
-      Application = "queue-worker"
+      Application = var.name
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,7 @@
 locals {
   user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    environment_name          = var.environment,
+    application_name          = replace(var.name, "-", "_"),
     region                    = var.aws_region,
     repo                      = var.ecr_repo,
     tag                       = var.image_tag,
@@ -9,7 +11,5 @@ locals {
     workers_per_instance      = var.workers_per_instance,
     enable_gpu                = var.enable_gpu,
     fluentbit_config_ssm_path = var.fluentbit_config_ssm_path,
-    name                      = var.name,
-    environment               = var.environment,
   })
 }

--- a/locals.tf
+++ b/locals.tf
@@ -9,5 +9,7 @@ locals {
     workers_per_instance      = var.workers_per_instance,
     enable_gpu                = var.enable_gpu,
     fluentbit_config_ssm_path = var.fluentbit_config_ssm_path,
+    name                      = var.name,
+    environment               = var.environment,
   })
 }

--- a/user_data.sh.tpl
+++ b/user_data.sh.tpl
@@ -77,6 +77,9 @@ services:
     volumes:
       - /opt/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    environment:
+      - APPLICATION=${name}
+      - ENVIRONMENT=${environment}
 %{ endif }
 YML
 

--- a/user_data.sh.tpl
+++ b/user_data.sh.tpl
@@ -78,8 +78,8 @@ services:
       - /opt/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
     environment:
-      - APPLICATION=${name}
-      - ENVIRONMENT=${environment}
+      - ENVIRONMENT=${environment_name}
+      - APPLICATION=${application_name}
 %{ endif }
 YML
 

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "environment" {
   type = string
 }
 
+variable "name" {
+  type        = string
+  description = "Name of the application or workload"
+}
+
 variable "aws_region" {
   type = string
 }
@@ -111,4 +116,10 @@ variable "worker_disk_size" {
 variable "queue_empty_minutes" {
   type    = number
   default = 15
+}
+
+variable "additional_policies" {
+  type        = list(string)
+  default     = []
+  description = "List of additional IAM policy documents to attach to the worker role"
 }


### PR DESCRIPTION
## Summary
- allow workload-specific names via `name`
- make Fluent Bit parameter path customizable
- support additional inline IAM policies

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(failed: could not connect to registry.terraform.io)*
- `terraform validate` *(failed: provider registry.terraform.io/hashicorp/aws missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f1d8c281c832cbbd08179729de2d3