### PR TITLE
Fix scale-in to zero when queue empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ aws autoscaling set-desired-capacity \
   --desired-capacity <N> --honor-cooldown
 ```
 
-The ASG will scale in automatically when the queue has been empty for the
+The ASG will scale down to zero automatically when the queue has been empty for the
 configured period (default 15 minutes).
 
 Set `enable_gpu` to `true` and choose a GPU instance type if the workload

--- a/alarms.tf
+++ b/alarms.tf
@@ -16,10 +16,10 @@ resource "aws_autoscaling_policy" "scale_in" {
   name                   = "${var.environment}-asg-scale-in"
   autoscaling_group_name = aws_autoscaling_group.workers.name
   policy_type            = "StepScaling"
-  adjustment_type        = "ChangeInCapacity"
+  adjustment_type        = "ExactCapacity"
 
   step_adjustment {
     metric_interval_lower_bound = 0
-    scaling_adjustment          = -1
+    scaling_adjustment          = 0
   }
 }


### PR DESCRIPTION
## Summary
- update autoscaling policy to set capacity to zero when queue is empty
- document that the ASG scales down to zero after queue is empty for 15 minutes

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684f2539c064832cbb58990ef4cb4f6e