### PR TITLE
Fix scale-in policy to use SimpleScaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ aws autoscaling set-desired-capacity \
   --desired-capacity <N> --honor-cooldown
 ```
 
-The ASG will scale down to zero automatically when the queue has been empty for the
-configured period (default 15 minutes).
+The ASG will scale down to its minimum capacity automatically when the queue has been empty for the
+configured period (default 15 minutes). The minimum is controlled by the
+`asg_min_size` variable.
 
 Set `enable_gpu` to `true` and choose a GPU instance type if the workload
 requires GPU access. When `enable_gpu` is `false` (the default), the instances

--- a/alarms.tf
+++ b/alarms.tf
@@ -15,11 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_empty" {
 resource "aws_autoscaling_policy" "scale_in" {
   name                   = "${var.environment}-asg-scale-in"
   autoscaling_group_name = aws_autoscaling_group.workers.name
-  policy_type            = "StepScaling"
+  policy_type            = "SimpleScaling"
   adjustment_type        = "ExactCapacity"
-
-  step_adjustment {
-    metric_interval_lower_bound = 0
-    scaling_adjustment          = 0
-  }
+  scaling_adjustment     = var.asg_min_size
 }


### PR DESCRIPTION
## Summary
- scale in workers using SimpleScaling instead of a step policy
- note scaling down honours `asg_min_size` in the docs

## Testing
- `terraform validate` *(fails: Missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_684f336a5f78832c8501e9b4bad76593