### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 delivops
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/gpu-example.tf
+++ b/examples/gpu-example.tf
@@ -122,5 +122,5 @@ module "simple-worker-asg" {
   asg_max_size              = var.asg_max_size
   asg_min_size              = var.asg_min_size
   asg_desired_capacity      = var.asg_desired_capacity
-  
+
 }

--- a/iam.tf
+++ b/iam.tf
@@ -18,8 +18,8 @@ resource "aws_iam_role_policy_attachment" "ecr_pull" {
 }
 
 resource "aws_iam_role_policy" "sqs" {
-  name  = "${var.environment}-${var.name}-sqs"
-  role  = aws_iam_role.worker.id
+  name = "${var.environment}-${var.name}-sqs"
+  role = aws_iam_role.worker.id
 
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## Summary
- Add `LICENSE` file (MIT, Copyright 2024 delivops)
- Apply `terraform fmt` whitespace normalisation

## Why
The repo was missing a `LICENSE` file, making the open-source license ambiguous.

## Validation
- `terraform fmt` ✓
- `terraform validate` ✓

## Risk
Docs/legal only — no resource changes.